### PR TITLE
chore: upgrade Kotlin, AGP, and Android compile SDK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp = "8.13.0"
-kotlin = "2.2.20"
+agp = "8.13.2"
+kotlin = "2.4.10"
 cmake = "3.22.1"
 android-minSdk = "24"
-android-compileSdk = "36"
+android-compileSdk = "37"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- Upgrade Kotlin to 2.4.10
- Upgrade Android Gradle Plugin to 8.13.2
- Raise the Android compile SDK to 37

## Testing

Not run (not requested)